### PR TITLE
Add support for subdomains

### DIFF
--- a/pdns_api.sh
+++ b/pdns_api.sh
@@ -43,8 +43,10 @@ fi
 # Load configuration
 . "$CONFIG"
 
-# Load domains
-all_zones="$(cat $ZONES_TXT)"
+# Load zones
+if [[ -f $ZONES_TXT ]]; then
+  all_zones="$(cat $ZONES_TXT)"
+fi
 
 ## Functions
 
@@ -78,10 +80,11 @@ setup() {
   domain="${1}"
   token="${2}"
 
-  # Find zone name, assuming:
-  # - subdomains are listed first
-  # - subdomains are zones in PowerDNS
   IFS='.' read -a domain_array <<< "$domain"
+
+  # Find zone name, assuming:
+  # - deeper zones are listed first
+  # - zones are present in PowerDNS
   for check_zone in $all_zones; do
     if [[ "$check_zone" = "$domain" ||
           "$check_zone" = "$(join . ${domain_array[@]:1})" ]]; then

--- a/pdns_api.sh
+++ b/pdns_api.sh
@@ -82,15 +82,17 @@ setup() {
 
   IFS='.' read -a domain_array <<< "$domain"
 
-  # Find zone name, assuming:
+  # Find zone name, cut off subdomains until match
+  # Assumptions:
   # - deeper zones are listed first
   # - zones are present in PowerDNS
   for check_zone in $all_zones; do
-    if [[ "$check_zone" = "$domain" ||
-          "$check_zone" = "$(join . ${domain_array[@]:1})" ]]; then
-      zone=$check_zone
-      break
-    fi
+    for (( j=${#domain_array[@]}-1; j>=0; j-- )); do
+      if [[ "$check_zone" = "$(join . ${domain_array[@]:j})" ]]; then
+        zone=$check_zone
+        break 2
+      fi
+    done
   done
 
   if [[ "$zone" = "" ]]; then


### PR DESCRIPTION
This patch looks for a 'zones.txt' file in the usual places that contains ordered (deeper zones first) zone names. It also assumes that each zone is actually a zone in PowerDNS.

If no file is found, it falls back to the old behaviour creating zone name from the rightmost two parts of the domain.

Tested on my private setup with staging, seems to work :)

[OT] Looks like Let's Encrypt do cache DNS lookups, so you can get false positives once LE got a positive, verified response.

PS: Sorry for adding some debug.