### PR TITLE
Various bugfixes

### DIFF
--- a/pdns_api.sh
+++ b/pdns_api.sh
@@ -205,13 +205,16 @@ setup_domain() {
   token="$2"
   zone=""
 
-  # Read domain parts into array
-  IFS='.' read -a domain_array <<< "${domain}"
+  # Record name
+  name="_acme-challenge.${domain}"
+
+  # Read name parts into array
+  IFS='.' read -a name_array <<< "${name}"
 
   # Find zone name, cut off subdomains until match
   for check_zone in ${all_zones}; do
-    for (( j=${#domain_array[@]}-1; j>=0; j-- )); do
-      if [[ "${check_zone}" = "$(join . ${domain_array[@]:j})" ]]; then
+    for (( j=${#name_array[@]}-1; j>=0; j-- )); do
+      if [[ "${check_zone}" = "$(join . ${name_array[@]:j})" ]]; then
         zone="${check_zone}"
         break 2
       fi
@@ -220,12 +223,9 @@ setup_domain() {
 
   # Fallback to creating zone from arguments
   if [[ -z "${zone}" ]]; then
-    zone="${domain_array[*]: -2:1}.${domain_array[*]: -1:1}"
+    zone="${name_array[*]: -2:1}.${name_array[*]: -1:1}"
     warn "zone not found, using '${zone}'"
   fi
-
-  # Record name
-  name="_acme-challenge.${domain}"
 
   # Some version incompatibilities
   if [[ "${VERSION}" -ge 1 ]]; then

--- a/pdns_api.sh
+++ b/pdns_api.sh
@@ -193,6 +193,7 @@ setup() {
 
   # Strip trailing dots from zones
   all_zones="${all_zones//$'.\n'/ }"
+  all_zones="${all_zones%.}"
 
   # Sort zones to list most specific first
   all_zones="$(<<< "${all_zones}" rev | sort | rev)"

--- a/pdns_api.sh
+++ b/pdns_api.sh
@@ -188,7 +188,7 @@ setup() {
   # Get a zone list from the API is none was set
   if [[ -z "${all_zones}" ]]; then
     request "GET" "${url}" ""
-    all_zones="$(<<< "${res//, /$',\n'}" get_json_string_value id)"
+    all_zones="$(<<< "${res//, /$',\n'}" get_json_string_value name)"
   fi
 
   # Strip trailing dots from zones


### PR DESCRIPTION
Hi!

This PR contains a fix for three bugs - one commit per bug.

1. The script attempted to enumerate zones using the "id" field rather than the "name" field. This causes lossage when trying to enumerate zones starting with _, such as when you have a zone for _acme_challenge.example.com, because the id field for some reason doesn't like starting with _. The name field however, remains correct.

2. The script attempts to strip trailing dots from inventoried zones. This however fails on the last inventoried zone in the powerdns install. This is fixed by this PR.

3. If a certificate is to be issued for example.com, the script starts searching for a proper zone to install the record at example.com. However, if example.com delegates _acme-challenge.example.com to your powerdns server, the original script would not find the proper zone to place it in. This PR fixes it by also looking for a zone named _acme-challenge.example.com.