### PR TITLE
implemented support for wildcard domains in preperation for ACMEv2

### DIFF
--- a/pdns_api.sh
+++ b/pdns_api.sh
@@ -203,15 +203,12 @@ setup_domain() {
   token="$2"
   zone=""
 
-  #record name
-  if [[ "${domain}" =~ ^[*]\.([^*]+) ]]; then
-        rootdomain="${BASH_REMATCH[1]}"
-	wildcard=true
-        name="_acme-challenge.${rootdomain}"
-	#warn "domain is a wildcard domain, acme challenge will be for ${name}"
+  # Record name
+  if [[ "${domain}" == "*."* ]]; then
+    name="_acme-challenge.${domain:2}"
+    debug "Domain ${domain} is a wildcard domain, ACME challenge will be for ${name}"
   else
-  	wildcard=false
-        name="_acme-challenge.${domain}"
+    name="_acme-challenge.${domain}"
   fi
 
   # Read name parts into array
@@ -370,9 +367,6 @@ main() {
 
     # Deploy a token
     if [[ "${hook}" = "deploy_challenge" ]]; then
-      if [[ $wildcard = true ]]; then
-      	warn "domain is a wildcard domain, acme challenge will be for ${name}"
-      fi
       requests[${zone}]="${req}$(deploy_rrset)"
     fi
 

--- a/pdns_api.sh
+++ b/pdns_api.sh
@@ -210,6 +210,7 @@ setup_domain() {
         name="_acme-challenge.${rootdomain}"
 	#warn "domain is a wildcard domain, acme challenge will be for ${name}"
   else
+  	wildcard=false
         name="_acme-challenge.${domain}"
   fi
 

--- a/pdns_api.sh
+++ b/pdns_api.sh
@@ -203,8 +203,15 @@ setup_domain() {
   token="$2"
   zone=""
 
-  # Record name
-  name="_acme-challenge.${domain}"
+  #record name
+  if [[ "${domain}" =~ ^[*]\.([^*]+) ]]; then
+        rootdomain="${BASH_REMATCH[1]}"
+	wildcard=true
+        name="_acme-challenge.${rootdomain}"
+	#warn "domain is a wildcard domain, acme challenge will be for ${name}"
+  else
+        name="_acme-challenge.${domain}"
+  fi
 
   # Read name parts into array
   IFS='.' read -ra name_array <<< "${name}"
@@ -362,6 +369,9 @@ main() {
 
     # Deploy a token
     if [[ "${hook}" = "deploy_challenge" ]]; then
+      if [[ $wildcard = true ]]; then
+      	warn "domain is a wildcard domain, acme challenge will be for ${name}"
+      fi
       requests[${zone}]="${req}$(deploy_rrset)"
     fi
 


### PR DESCRIPTION
Added the ability to deal with wildcard domains in preparation for the rollout by letsencrypt next month. Tested using the V2 staging endpoint and the latest version of dehydrated.