### PR TITLE
Add parameter PDNS_SUFFIX for CNAME redirection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ Add the settings for your PowerDNS API to Dehydrated's `config`
 or a `config` file next to `pdns_api.sh`:
 
 ```sh
-PDNS_HOST=ns0.example.com  # API Host. Can also be a URL, eg: http://ns0.example.com:8081
-PDNS_PORT=8081             # Optional. Defaults to 8081
-PDNS_KEY=secret            # API key
-PDNS_SERVER=localhost      # Optional. Server for the API to use, usually `localhost`
-PDNS_VERSION=1             # Optional. API version, 0 for anything under PowerDNS 4
-PDNS_WAIT=300              # Optional. Delay for when slaves are slow
-PDNS_ZONES_TXT=zones.txt   # Optional. File containing zones to use (see below).
-PDNS_NO_NOTIFY=yes         # Optional. Disable sending a notification after updating the zone.
-PDNS_SUFFIX=.v.example.com # Optional. When using a dedicated validation zone via CNAME redirection
+PDNS_HOST=ns0.example.com # API Host. Can also be a URL, eg: http://ns0.example.com:8081
+PDNS_PORT=8081            # Optional. Defaults to 8081
+PDNS_KEY=secret           # API key
+PDNS_SERVER=localhost     # Optional. Server for the API to use, usually `localhost`
+PDNS_VERSION=1            # Optional. API version, 0 for anything under PowerDNS 4
+PDNS_WAIT=300             # Optional. Delay for when slaves are slow
+PDNS_ZONES_TXT=zones.txt  # Optional. File containing zones to use (see below).
+PDNS_NO_NOTIFY=yes        # Optional. Disable sending a notification after updating the zone.
+PDNS_SUFFIX=v.example.com # Optional. When using a dedicated validation zone via CNAME redirection
 ```
 
 Configure the DNS hook by adding the following to your Dehydrated config:

--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@ Add the settings for your PowerDNS API to Dehydrated's `config`
 or a `config` file next to `pdns_api.sh`:
 
 ```sh
-PDNS_HOST=ns0.example.com # API Host. Can also be a URL, eg: http://ns0.example.com:8081
-PDNS_PORT=8081            # Optional. Defaults to 8081
-PDNS_KEY=secret           # API key
-PDNS_SERVER=localhost     # Optional. Server for the API to use, usually `localhost`
-PDNS_VERSION=1            # Optional. API version, 0 for anything under PowerDNS 4
-PDNS_WAIT=300             # Optional. Delay for when slaves are slow
-PDNS_ZONES_TXT=zones.txt  # Optional. File containing zones to use (see below).
-PDNS_NO_NOTIFY=yes        # Optional. Disable sending a notification after updating the zone.
+PDNS_HOST=ns0.example.com  # API Host. Can also be a URL, eg: http://ns0.example.com:8081
+PDNS_PORT=8081             # Optional. Defaults to 8081
+PDNS_KEY=secret            # API key
+PDNS_SERVER=localhost      # Optional. Server for the API to use, usually `localhost`
+PDNS_VERSION=1             # Optional. API version, 0 for anything under PowerDNS 4
+PDNS_WAIT=300              # Optional. Delay for when slaves are slow
+PDNS_ZONES_TXT=zones.txt   # Optional. File containing zones to use (see below).
+PDNS_NO_NOTIFY=yes         # Optional. Disable sending a notification after updating the zone.
+PDNS_SUFFIX=.v.example.com # Optional. When using a dedicated validation zone via CNAME redirection
 ```
 
 Configure the DNS hook by adding the following to your Dehydrated config:

--- a/pdns_api.sh
+++ b/pdns_api.sh
@@ -236,6 +236,13 @@ setup() {
 
   # Sort zones to list most specific first
   all_zones="$(<<< "${all_zones}" rev | sort | rev)"
+
+  # Set suffix in case of CNAME redirection
+  if [[ -n "${PDNS_SUFFIX:-}" ]]; then
+      suffix="${PDNS_SUFFIX}"
+  else
+      suffix=""
+  fi
 }
 
 setup_domain() {
@@ -245,7 +252,7 @@ setup_domain() {
   zone=""
 
   # Record name
-  name="_acme-challenge.${domain}"
+  name="_acme-challenge.${domain}${suffix}"
 
   # Read name parts into array
   IFS='.' read -ra name_array <<< "${name}"

--- a/pdns_api.sh
+++ b/pdns_api.sh
@@ -239,7 +239,7 @@ setup() {
 
   # Set suffix in case of CNAME redirection
   if [[ -n "${PDNS_SUFFIX:-}" ]]; then
-      suffix="${PDNS_SUFFIX}"
+      suffix=".${PDNS_SUFFIX}"
   else
       suffix=""
   fi


### PR DESCRIPTION
If you want to restrict to API access to a single zone for security reasons or - like in my case - are using powerdns's BIND backend, it is possible to redirect the challenge to an external zone.

For the sake of simplicity, the external zone can be appended to the actual name of the zone to be validated.