### PR TITLE
Respect CURL_OPTS variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ PDNS_WAIT=300             # Optional. Delay for when slaves are slow
 PDNS_ZONES_TXT=zones.txt  # Optional. File containing zones to use (see below).
 PDNS_NO_NOTIFY=yes        # Optional. Disable sending a notification after updating the zone.
 PDNS_SUFFIX=v.example.com # Optional. When using a dedicated validation zone via CNAME redirection
+PDNS_CURL_OPTS="-k"       # Optional. Pass some options to curl
+                          #   CURL_OPTS variable will be used if PDNS_CURL_OPTS undefined
+                          #   To ignore CURL_OPTS you could set PDNS_CURL_OPTS to empty string
 ```
 
 Configure the DNS hook by adding the following to your Dehydrated config:

--- a/pdns_api.sh
+++ b/pdns_api.sh
@@ -132,6 +132,8 @@ load_config() {
 
   # Check optional settings
   [[ -n "${PDNS_PORT:-}" ]] || PDNS_PORT=8081
+  # Check if PDNS_CURL_OPTS is unset
+  [[ -n "${PDNS_CURL_OPTS+empty}" ]] || PDNS_CURL_OPTS=${CURL_OPTS:-}
 }
 
 # Load the zones from file
@@ -164,7 +166,7 @@ request() {
 
   # Perform the request
   # This is wrappend in an if to avoid the exit on error
-  if ! res="$(curl -sSfL --stderr - --request "${method}" --header "${content_header}" --header "${api_header}" --data "${data}" "${url}")"; then
+  if ! res="$(curl ${PDNS_CURL_OPTS:-} -sSfL --stderr - --request "${method}" --header "${content_header}" --header "${api_header}" --data "${data}" "${url}")"; then
     error=true
   fi
 

--- a/pdns_api.sh
+++ b/pdns_api.sh
@@ -171,6 +171,7 @@ request() {
   fi
 
   # Debug output
+  debug "# Request"
   debug "Method: ${method}"
   debug "URL: ${url}"
   debug "Data: ${data}"
@@ -245,6 +246,13 @@ setup() {
   else
       suffix=""
   fi
+
+  # Debug setup result
+  debug "# Setup"
+  debug "API version: ${PDNS_VERSION}"
+  debug "PDNS server: ${PDNS_SERVER}"
+  debug "Zones: ${all_zones}"
+  debug "Suffix: \"${suffix}\""
 }
 
 setup_domain() {
@@ -420,6 +428,7 @@ main() {
     setup_domain "${domain}" "${t}"
 
     # Debug output
+    debug "# Domain"
     debug "Name:  ${name}"
     debug "Token: ${token}"
     debug "Zone:  ${zone}"


### PR DESCRIPTION
dehydrated uses CURL_OPTS variable to pass optional parameters to curl:
https://github.com/lukas2511/dehydrated/blob/v0.6.5/docs/examples/config

IMHO it is a good idea to support this in pdns_api.sh as well.