### PR TITLE
Enable null globs when scanning for config.d/*.sh

### DIFF
--- a/pdns_api.sh
+++ b/pdns_api.sh
@@ -103,8 +103,10 @@ load_config() {
     if [[ -n "${ZSH_VERSION:-}" ]]
     then
       set +o noglob
+      setopt null_glob
     else
       set +f
+      shopt -s nullglob
     fi
 
     for check_config_d in "${CONFIG_D}"/*.sh; do
@@ -121,8 +123,10 @@ load_config() {
     if [[ -n "${ZSH_VERSION:-}" ]]
     then
       set -o noglob
+      setopt no_null_glob
     else
       set -f
+      shopt -u nullglob
     fi
   fi
 


### PR DESCRIPTION
Without this, an empty directory leads to an false error complaining that the file `/etc/dehydrated/config.d/*.sh` is not readable or doesn't exist.

With `nullglob` set, the glob, if it doesn't match anything, will expand into null rather than returning the glob string, causing an empty config.d folder to not throw an error.